### PR TITLE
Update building_a_driver.md

### DIFF
--- a/vsdriver/building_a_driver.md
+++ b/vsdriver/building_a_driver.md
@@ -9,7 +9,7 @@
 -   [Troubleshooting tip for building a driver](#troubleshooting)
 -   [Related topics](#related_topics)
 
-This topic describes how to build a driver with the Windows Driver Kit (WDK). WDK 10 is fully integrated with Microsoft Visual Studio. You can build a driver using the Visual Studio development environment, or you can build a driver directly from the command line using the Microsoft Build Engine ([MSBuild](http://go.microsoft.com/fwlink/p/?linkid=262804)).
+This topic describes how you can build a driver with the Windows Driver Kit (WDK). WDK 10 is fully integrated with Microsoft Visual Studio. You can build a driver using the Visual Studio development environment, or you can build a driver directly from the command line by using the Microsoft Build Engine ([MSBuild](http://go.microsoft.com/fwlink/p/?linkid=262804)).
 
 You can use any edition of Microsoft Visual Studio 2015, including Microsoft Visual Studio Community 2015, to build drivers for:
 
@@ -17,7 +17,7 @@ You can use any edition of Microsoft Visual Studio 2015, including Microsoft Vi
 -   Windows 8.1
 -   Windows 7
 
-**Important**  Starting in Windows Driver Kit (WDK) 8, MSBuild replaced the Windows Build Utility (Build.exe) that was used in previous versions of the WDK. The WDK now uses the same compiler and build tools that you use to build Visual Studio projects. Driver projects that were built with previous versions of the WDK must be converted to work in the Visual Studio environment. You can run a conversion utility from the command line, or you can convert an existing driver by creating new Visual Studio project from existing sources. For more information, see [Creating a Driver From Existing Source Files](creating_a_driver_from_existing_source_files.md) and [WDK and the Visual Studio build environment](https://msdn.microsoft.com/en-us/Library/Windows/Hardware/Hh454286(v=vs.85).aspx).
+**Important**  Starting in Windows Driver Kit (WDK) 8, MSBuild replaced the Windows Build Utility (Build.exe). The WDK now uses the same compiler and build tools that you use to build Visual Studio projects. Driver projects that were built with previous versions of the WDK must be converted to work in the Visual Studio environment. You can run a conversion utility from the command line, or you can convert an existing driver by creating new Visual Studio project from existing sources. For more info, see [Creating a Driver From Existing Source Files](creating_a_driver_from_existing_source_files.md) and [WDK and the Visual Studio build environment](https://msdn.microsoft.com/en-us/Library/Windows/Hardware/Hh454286(v=vs.85).aspx).
 
  
 
@@ -80,7 +80,7 @@ You can build a driver from the command line using the **Visual Studio Command P
 <span id="configure_project_props"></span><span id="CONFIGURE_PROJECT_PROPS"></span>Configuring project properties for your driver and driver package
 -----------------------------------------------------------------------------------------------------------------------------------------------------
 
-Property pages allow you to configure and set options for your driver and driver package. You can choose to configure your driver so that it is automatically signed when you build your solution, or automatically deployed to a remote test computer.
+You use **property pages** to configure and set options for your driver and driver package. You can choose to configure your driver so that it is automatically signed when you build your solution, or automatically deployed to a remote test computer.
 
 The WDK provides a number of command-line tools, such as [Stampinf](https://msdn.microsoft.com/en-us/Library/Windows/Hardware/Ff552786(v=vs.85).aspx) and [WPP Preprocessor (WPP Tracing)](https://msdn.microsoft.com/en-us/Library/Windows/Hardware/Ff556201(v=vs.85).aspx), that are commonly included in the build process. These tools are not distributed with Visual Studio. To combine these tools with the Visual Studio build environment they are wrapped as [WDK tasks for MSBuild](https://msdn.microsoft.com/en-us/Library/Windows/Hardware/Hh454288(v=vs.85).aspx). If you use one of the driver templates or have an existing driver that you have converted, these property pages might already exist for your project. If not, the property pages are automatically added to your project as you add the related file types to the project or solution (for example, .mc or .man files for the message compiler). For more information, see [WDK and the Visual Studio build environment](https://msdn.microsoft.com/en-us/Library/Windows/Hardware/Hh454286(v=vs.85).aspx)
 
@@ -141,18 +141,18 @@ The following tip can help you to troubleshoot problems when you use the WDK and
 <span id="related_topics"></span>Related topics
 -----------------------------------------------
 
-[Building in Visual Studio](http://go.microsoft.com/fwlink/p/?linkid=227872)
-[Building Drivers for Different Versions of Windows](building_drivers_for_different_versions_of_windows.md)
-[Using the Microsoft C Runtime with User-Mode Drivers and Desktop Apps](using_the_microsoft_c_runtime_with_user_mode_drivers_and_apps.md)
-[ProjectUpgradeTool](https://msdn.microsoft.com/en-us/Library/Windows/Hardware/Dn265174(v=vs.85).aspx)
-[MSBuild](http://go.microsoft.com/fwlink/p/?linkid=262804)
-[Creating a Driver From Existing Source Files](creating_a_driver_from_existing_source_files.md)
-[WDK and the Visual Studio build environment](https://msdn.microsoft.com/en-us/Library/Windows/Hardware/Hh454286(v=vs.85).aspx)
-[Signing a Driver](signing_a_driver.md)
-[Deploying a Driver to a Test Computer](deploying_a_driver_to_a_test_computer.md)
- 
+* [Building in Visual Studio](http://go.microsoft.com/fwlink/p/?linkid=227872)
+* [Building Drivers for Different Versions of Windows](building_drivers_for_different_versions_of_windows.md)
+* [Using the Microsoft C Runtime with User-Mode Drivers and Desktop Apps](using_the_microsoft_c_runtime_with_user_mode_drivers_and_apps.md)
+* [ProjectUpgradeTool](https://msdn.microsoft.com/en-us/Library/Windows/Hardware/Dn265174(v=vs.85).aspx)
+* [MSBuild](http://go.microsoft.com/fwlink/p/?linkid=262804)
+* [Creating a Driver From Existing Source Files](creating_a_driver_from_existing_source_files.md)
+* [WDK and the Visual Studio build environment](https://msdn.microsoft.com/en-us/Library/Windows/Hardware/Hh454286(v=vs.85).aspx)
+* [Signing a Driver](signing_a_driver.md)
+* [Deploying a Driver to a Test Computer](deploying_a_driver_to_a_test_computer.md)
 
- 
+
+
 
 [Send comments about this topic to Microsoft](mailto:wsddocfb@microsoft.com?subject=Documentation%20feedback%20[VsDriver\vsdriver]:%20Building%20a%20Driver%20with%20the%20WDK%20%20RELEASE:%20(9/30/2015)&body=%0A%0APRIVACY%20STATEMENT%0A%0AWe%20use%20your%20feedback%20to%20improve%20the%20documentation.%20We%20don't%20use%20your%20email%20address%20for%20any%20other%20purpose,%20and%20we'll%20remove%20your%20email%20address%20from%20our%20system%20after%20the%20issue%20that%20you're%20reporting%20is%20fixed.%20While%20we're%20working%20to%20fix%20this%20issue,%20we%20might%20send%20you%20an%20email%20message%20to%20ask%20for%20more%20info.%20Later,%20we%20might%20also%20send%20you%20an%20email%20message%20to%20let%20you%20know%20that%20we've%20addressed%20your%20feedback.%0A%0AFor%20more%20info%20about%20Microsoft's%20privacy%20policy,%20see%20http://privacy.microsoft.com/en-us/default.aspx. "Send comments about this topic to Microsoft")
 


### PR DESCRIPTION
A little bit here and there. The See Also links were smushed into a run-on paragraph. May be a migration issue? I changed them into a bulleted list, since it was unclear why they weren't appearing each on their own line.